### PR TITLE
Enlever un logging inutile

### DIFF
--- a/src/app/core/services/olympic.service.ts
+++ b/src/app/core/services/olympic.service.ts
@@ -32,10 +32,8 @@ export class OlympicService {
   }
 
   getOlympicById(id: number): Observable<OlympicCountry> {
-    console.log(id)
-    return this.olympics$.asObservable().pipe(tap(v => console.log(v)), filter(v => v.length > 0), first(), map(
+    return this.olympics$.asObservable().pipe(filter(v => v.length > 0), first(), map(
       (v) => {
-        console.log(v)
         const found = v.find(c => c.id == id)
         if (!found) {
           throw new Error("not found")


### PR DESCRIPTION
Certains messages de debugging étaient encore affichés, il était important de les supprimer pour rendre le code prêt à la production.